### PR TITLE
Add link to console log of run

### DIFF
--- a/app/partials/runs.html
+++ b/app/partials/runs.html
@@ -10,7 +10,15 @@
 		</tr>
 		<tr ng-repeat="run in runs">
 			<td class="t-data t-seq">{{run.seq}}</td>
-			<td class="t-data t-value">{{run.value}}</td>
+			<td ng-if="run.build_url" class="t-data t-value">
+			  <a href="{{run.build_url}}consoleFull"
+			     target="_blank">
+                            {{run.value}}
+			  </a>
+                        </td>
+			<td ng-if="!run.build_url" class="t-data t-value">
+                            {{run.value}}
+                        </td>
 			<td class="t-data t-report">
 				<a ng-repeat="snapshot in run.snapshots"
 					 href="http://cbmonitor.sc.couchbase.com/reports/html/?snapshot={{snapshot}}"

--- a/datasources.go
+++ b/datasources.go
@@ -35,7 +35,7 @@ var ddocs = map[string]string{
 				"map": "function (doc, meta) {if (!doc.obsolete) {emit([doc.metric, doc.build], doc.value);}}"
 			},
 			"value_and_snapshots_by_build_and_metric": {
-				"map": "function (doc, meta) {emit([doc.metric, doc.build], [doc.value, doc.snapshots, doc.master_events]);}"
+				"map": "function (doc, meta) {emit([doc.metric, doc.build], [doc.value, doc.snapshots, doc.master_events, doc.build_url || null]);}"
 			},
 			"value_and_obsolete_by_build_and_metric": {
 				"map": "function (doc, meta) {emit([doc.metric, doc.build], [doc.value, doc.obsolete == true]);}"
@@ -178,11 +178,18 @@ func (ds *DataSource) GetAllRuns(metric string, build string) []byte {
 		} else {
 			master_events = ""
 		}
+		var build_url string
+		if str, ok := row.Value.([]interface{})[3].(string); ok {
+			build_url = str
+		} else {
+			build_url = ""
+		}
 		benchmark := map[string]interface{}{
 			"seq":           strconv.Itoa(i + 1),
 			"value":         strconv.FormatFloat(row.Value.([]interface{})[0].(float64), 'f', 1, 64),
 			"snapshots":     row.Value.([]interface{})[1],
 			"master_events": master_events,
+			"build_url":     build_url,
 		}
 		benchmarks = append(benchmarks, benchmark)
 	}


### PR DESCRIPTION
So far it was hard to find out which run on the perf infrastructure created
the output of ShowFast. If a link to the run was provided, the value of the
run will become a link to the console log of the run.