### PR TITLE
Add recovery tab for MOI and PLASMA

### DIFF
--- a/app/menu.json
+++ b/app/menu.json
@@ -94,6 +94,8 @@
 			}, {
 				"id": "incremental_moi", "title": "Incremental MOI"
 			}, {
+				"id": "recovery_moi", "title": "Recovery MOI"
+			}, {
 				"id": "plasma_lat", "title": "Latency PLASMA"
 			}, {
 				"id": "plasma_thr", "title": "Throughput PLASMA"
@@ -101,6 +103,8 @@
 				"id": "initial_plasma", "title": "Initial PLASMA"
 			}, {
 				"id": "incremental_plasma", "title": "Incremental PLASMA"
+			}, {
+				"id": "recovery_plasma", "title": "Recovery PLASMA"
 			}]
 		},
 		"xdcr": {


### PR DESCRIPTION
Adding extra tabs for recovery now, as discussed offline we have to add third level in showfast as number of tabs in GSI are huge