### PR TITLE
Remove sub categories from  Continuous Backup tab

### DIFF
--- a/app/menu.json
+++ b/app/menu.json
@@ -258,7 +258,7 @@
             },{
                 "id": "hdd_pipeline", "title": "HDD Pipeline", "subCategories": ["SQLite", "ForestDB"]
             },{
-                "id": "continuous_backup", "title": "Continuous Backup", "subCategories": ["Backup", "Restore"]
+                "id": "continuous_backup", "title": "Continuous Backup", "subCategories": []
             }]
         },
         "syncgateway": {

--- a/app/menu_full.json
+++ b/app/menu_full.json
@@ -284,7 +284,7 @@
             },{
                 "id": "hdd_pipeline", "title": "HDD Pipeline", "subCategories": ["SQLite", "ForestDB"]
             },{
-                "id": "continuous_backup", "title": "Continuous Backup", "subCategories": ["Backup", "Restore"]
+                "id": "continuous_backup", "title": "Continuous Backup", "subCategories": []
             }]
         },
         "syncgateway": {


### PR DESCRIPTION
Remove the 'Backup' & 'Restore' sub-categories from the recently added 'Continuous Backup' tab.