### PR TITLE
Add Retention tab to tools

### DIFF
--- a/app/menu.json
+++ b/app/menu.json
@@ -259,6 +259,8 @@
                 "id": "hdd_pipeline", "title": "HDD Pipeline", "subCategories": ["SQLite", "ForestDB"]
             },{
                 "id": "continuous_backup", "title": "Continuous Backup", "subCategories": []
+            },{
+                "id": "retention", "title": "Retention", "subCategories": []
             }]
         },
         "syncgateway": {

--- a/app/menu_full.json
+++ b/app/menu_full.json
@@ -285,6 +285,8 @@
                 "id": "hdd_pipeline", "title": "HDD Pipeline", "subCategories": ["SQLite", "ForestDB"]
             },{
                 "id": "continuous_backup", "title": "Continuous Backup", "subCategories": []
+            },{
+                "id": "retention", "title": "Retention", "subCategories": []
             }]
         },
         "syncgateway": {


### PR DESCRIPTION
Adds a new 'Retention' tab to the tools section in Showfast.
This tab will contain results from the testing of the 'Backup Service Retention Policy' feature.